### PR TITLE
Fix logger warning call and add tests

### DIFF
--- a/AssetRipper.sln
+++ b/AssetRipper.sln
@@ -131,6 +131,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssetRipper.Export.Modules.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssetRipper.Import", "Source\AssetRipper.Import\AssetRipper.Import.csproj", "{A1ACC369-4E2E-4E58-8BA6-034609B54E6A}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssetRipper.Import.Tests", "Source\AssetRipper.Import.Tests\AssetRipper.Import.Tests.csproj", "{78935941-587C-4FD0-954D-61C46149B062}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssetRipper.Export.Modules.Shaders", "Source\AssetRipper.Export.Modules.Shader\AssetRipper.Export.Modules.Shaders.csproj", "{680FA140-1836-45D8-BE5C-1885BB657864}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssetRipper.Export.UnityProjects", "Source\AssetRipper.Export.UnityProjects\AssetRipper.Export.UnityProjects.csproj", "{65C9ACC0-4B34-4289-9F8C-A3619D48AB3D}"
@@ -290,11 +292,15 @@ Global
 		{F5D07C87-ADEE-44E3-995E-7DCD6463E4E3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F5D07C87-ADEE-44E3-995E-7DCD6463E4E3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F5D07C87-ADEE-44E3-995E-7DCD6463E4E3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A1ACC369-4E2E-4E58-8BA6-034609B54E6A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A1ACC369-4E2E-4E58-8BA6-034609B54E6A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A1ACC369-4E2E-4E58-8BA6-034609B54E6A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A1ACC369-4E2E-4E58-8BA6-034609B54E6A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{680FA140-1836-45D8-BE5C-1885BB657864}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {A1ACC369-4E2E-4E58-8BA6-034609B54E6A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {A1ACC369-4E2E-4E58-8BA6-034609B54E6A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {A1ACC369-4E2E-4E58-8BA6-034609B54E6A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {A1ACC369-4E2E-4E58-8BA6-034609B54E6A}.Release|Any CPU.Build.0 = Release|Any CPU
+                {78935941-587C-4FD0-954D-61C46149B062}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {78935941-587C-4FD0-954D-61C46149B062}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {78935941-587C-4FD0-954D-61C46149B062}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {78935941-587C-4FD0-954D-61C46149B062}.Release|Any CPU.Build.0 = Release|Any CPU
+                {680FA140-1836-45D8-BE5C-1885BB657864}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{680FA140-1836-45D8-BE5C-1885BB657864}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{680FA140-1836-45D8-BE5C-1885BB657864}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{680FA140-1836-45D8-BE5C-1885BB657864}.Release|Any CPU.Build.0 = Release|Any CPU

--- a/Source/AssetRipper.Import.Tests/AssetRipper.Import.Tests.csproj
+++ b/Source/AssetRipper.Import.Tests/AssetRipper.Import.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <OutputPath>..\0Bins\Other\AssetRipper.Import.Tests\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>..\0Bins\obj\AssetRipper.Import.Tests\$(Configuration)\</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.8.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AssetRipper.Import\AssetRipper.Import.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Source/AssetRipper.Import.Tests/LoggerTests.cs
+++ b/Source/AssetRipper.Import.Tests/LoggerTests.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using AssetRipper.Import.Logging;
+
+namespace AssetRipper.Import.Tests;
+
+internal class MemoryLogger : ILogger
+{
+    public readonly List<(LogType Type, LogCategory Category, string Message)> Messages = new();
+    public void Log(LogType type, LogCategory category, string message)
+    {
+        Messages.Add((type, category, message));
+    }
+
+    public void BlankLine(int numLines) { }
+}
+
+public class LoggerTests
+{
+    private MemoryLogger _memoryLogger = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        Logger.Clear();
+        _memoryLogger = new MemoryLogger();
+        Logger.Add(_memoryLogger);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Logger.Clear();
+    }
+
+    [Test]
+    public void InfoMessageIsLogged()
+    {
+        const string message = "test info";
+        Logger.Info(message);
+        Assert.That(_memoryLogger.Messages, Has.Count.EqualTo(1));
+        var entry = _memoryLogger.Messages[0];
+        Assert.Multiple(() =>
+        {
+            Assert.That(entry.Type, Is.EqualTo(LogType.Info));
+            Assert.That(entry.Category, Is.EqualTo(LogCategory.None));
+            Assert.That(entry.Message, Is.EqualTo(message));
+        });
+    }
+
+    [Test]
+    public void WarningMessageWithCategoryIsLogged()
+    {
+        const string message = "test warning";
+        Logger.Warning(LogCategory.Import, message);
+        Assert.That(_memoryLogger.Messages, Has.Count.EqualTo(1));
+        var entry = _memoryLogger.Messages[0];
+        Assert.Multiple(() =>
+        {
+            Assert.That(entry.Type, Is.EqualTo(LogType.Warning));
+            Assert.That(entry.Category, Is.EqualTo(LogCategory.Import));
+            Assert.That(entry.Message, Is.EqualTo(message));
+        });
+    }
+}

--- a/Source/AssetRipper.Import.Tests/Usings.cs
+++ b/Source/AssetRipper.Import.Tests/Usings.cs
@@ -1,0 +1,1 @@
+﻿global using NUnit.Framework;

--- a/Source/AssetRipper.Import/Structure/Assembly/AIAssembler.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/AIAssembler.cs
@@ -11,7 +11,7 @@ public static class AIAssembler
                      Environment.GetEnvironmentVariable("CLAUDE_API_KEY");
         if (string.IsNullOrEmpty(key))
         {
-            Logger.Warn(LogCategory.Import, "No AI API key provided. Skipping level 4 assembly.");
+            Logger.Warning(LogCategory.Import, "No AI API key provided. Skipping level 4 assembly.");
             return;
         }
 


### PR DESCRIPTION
## Summary
- fix `Logger.Warn` call in AI assembler
- add `AssetRipper.Import.Tests` project
- add memory logger unit tests
- register new test project in solution

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d7f936790832aba5e6a08a43c1c3c