### PR TITLE
Enable AI decomp with API key settings

### DIFF
--- a/Source/AssetRipper.GUI.Web/GameFileLoader.cs
+++ b/Source/AssetRipper.GUI.Web/GameFileLoader.cs
@@ -40,12 +40,14 @@ public static class GameFileLoader
 		}
 	}
 
-	public static void LoadAndProcess(IReadOnlyList<string> paths)
-	{
-		Reset();
-		Settings.LogConfigurationValues();
-		GameData = ExportHandler.LoadAndProcess(paths);
-	}
+        public static void LoadAndProcess(IReadOnlyList<string> paths)
+        {
+                Reset();
+                Settings.LogConfigurationValues();
+                Environment.SetEnvironmentVariable("OPENAI_API_KEY", Settings.ImportSettings.OpenAIApiKey);
+                Environment.SetEnvironmentVariable("CLAUDE_API_KEY", Settings.ImportSettings.AnthropicApiKey);
+                GameData = ExportHandler.LoadAndProcess(paths);
+        }
 
 	public static void ExportUnityProject(string path)
 	{

--- a/Source/AssetRipper.GUI.Web/Pages/Settings/SettingsPage.cs
+++ b/Source/AssetRipper.GUI.Web/Pages/Settings/SettingsPage.cs
@@ -103,15 +103,23 @@ public sealed partial class SettingsPage : DefaultPage
 								}
 							}
 
-							using (new Div(writer).WithClass("row").End())
-							{
-								using (new Div(writer).WithClass("col").End())
-								{
-									WriteTextAreaForTargetVersion(writer);
-								}
-							}
-						}
-					}
+                                                        using (new Div(writer).WithClass("row").End())
+                                                        {
+                                                                using (new Div(writer).WithClass("col").End())
+                                                                {
+                                                                        WriteTextAreaForTargetVersion(writer);
+                                                                }
+                                                                using (new Div(writer).WithClass("col").End())
+                                                                {
+                                                                        WriteTextAreaForOpenAIApiKey(writer);
+                                                                }
+                                                                using (new Div(writer).WithClass("col").End())
+                                                                {
+                                                                        WriteTextAreaForAnthropicApiKey(writer);
+                                                                }
+                                                        }
+                                                }
+                                        }
 
 					using (new Div(writer).WithClass("border rounded p-3 m-2").End())
 					{
@@ -204,17 +212,41 @@ public sealed partial class SettingsPage : DefaultPage
 			.Close();
 	}
 
-	private static void WriteTextAreaForTargetVersion(TextWriter writer)
-	{
-		new Label(writer).WithClass("form-label").WithFor(nameof(Configuration.ImportSettings.TargetVersion)).Close(Localization.TargetVersionForVersionChanging);
-		new Input(writer)
-			.WithType("text")
-			.WithClass("form-control")
-			.WithId(nameof(Configuration.ImportSettings.TargetVersion))
-			.WithName(nameof(Configuration.ImportSettings.TargetVersion))
-			.WithValue(Configuration.ImportSettings.TargetVersion.ToString())
-			.Close();
-	}
+        private static void WriteTextAreaForTargetVersion(TextWriter writer)
+        {
+                new Label(writer).WithClass("form-label").WithFor(nameof(Configuration.ImportSettings.TargetVersion)).Close(Localization.TargetVersionForVersionChanging);
+                new Input(writer)
+                        .WithType("text")
+                        .WithClass("form-control")
+                        .WithId(nameof(Configuration.ImportSettings.TargetVersion))
+                        .WithName(nameof(Configuration.ImportSettings.TargetVersion))
+                        .WithValue(Configuration.ImportSettings.TargetVersion.ToString())
+                        .Close();
+        }
+
+        private static void WriteTextAreaForOpenAIApiKey(TextWriter writer)
+        {
+                new Label(writer).WithClass("form-label").WithFor(nameof(Configuration.ImportSettings.OpenAIApiKey)).Close("OpenAI API Key");
+                new Input(writer)
+                        .WithType("text")
+                        .WithClass("form-control")
+                        .WithId(nameof(Configuration.ImportSettings.OpenAIApiKey))
+                        .WithName(nameof(Configuration.ImportSettings.OpenAIApiKey))
+                        .WithValue(Configuration.ImportSettings.OpenAIApiKey ?? string.Empty)
+                        .Close();
+        }
+
+        private static void WriteTextAreaForAnthropicApiKey(TextWriter writer)
+        {
+                new Label(writer).WithClass("form-label").WithFor(nameof(Configuration.ImportSettings.AnthropicApiKey)).Close("Anthropic API Key");
+                new Input(writer)
+                        .WithType("text")
+                        .WithClass("form-control")
+                        .WithId(nameof(Configuration.ImportSettings.AnthropicApiKey))
+                        .WithName(nameof(Configuration.ImportSettings.AnthropicApiKey))
+                        .WithValue(Configuration.ImportSettings.AnthropicApiKey ?? string.Empty)
+                        .Close();
+        }
 
 	private static void WriteCheckBox(TextWriter writer, string label, bool @checked, string id, bool disabled = false)
 	{

--- a/Source/AssetRipper.GUI.Web/Pages/Settings/SettingsPage.g.cs
+++ b/Source/AssetRipper.GUI.Web/Pages/Settings/SettingsPage.g.cs
@@ -25,9 +25,15 @@ partial class SettingsPage
 			case nameof(ImportSettings.DefaultVersion):
 				Configuration.ImportSettings.DefaultVersion = TryParseUnityVersion(value);
 				break;
-			case nameof(ImportSettings.TargetVersion):
-				Configuration.ImportSettings.TargetVersion = TryParseUnityVersion(value);
-				break;
+                        case nameof(ImportSettings.TargetVersion):
+                                Configuration.ImportSettings.TargetVersion = TryParseUnityVersion(value);
+                                break;
+                        case nameof(ImportSettings.OpenAIApiKey):
+                                Configuration.ImportSettings.OpenAIApiKey = value;
+                                break;
+                        case nameof(ImportSettings.AnthropicApiKey):
+                                Configuration.ImportSettings.AnthropicApiKey = value;
+                                break;
 			case nameof(ProcessingSettings.BundledAssetsExportMode):
 				Configuration.ProcessingSettings.BundledAssetsExportMode = TryParseEnum<BundledAssetsExportMode>(value);
 				break;

--- a/Source/AssetRipper.Import/Configuration/ImportSettings.cs
+++ b/Source/AssetRipper.Import/Configuration/ImportSettings.cs
@@ -37,14 +37,28 @@ public sealed record class ImportSettings
 	/// <summary>
 	/// The target version to convert all assets to. Experimental
 	/// </summary>
-	[JsonConverter(typeof(UnityVersionJsonConverter))]
-	public UnityVersion TargetVersion { get; set; }
+        [JsonConverter(typeof(UnityVersionJsonConverter))]
+        public UnityVersion TargetVersion { get; set; }
+
+        /// <summary>
+        /// API key for OpenAI GPT models used in script level 4 recovery.
+        /// Stored in plain text. Keep this safe.
+        /// </summary>
+        public string? OpenAIApiKey { get; set; }
+
+        /// <summary>
+        /// API key for Anthropic Claude models used in script level 4 recovery.
+        /// Stored in plain text. Keep this safe.
+        /// </summary>
+        public string? AnthropicApiKey { get; set; }
 
 	public void Log()
 	{
 		Logger.Info(LogCategory.General, $"{nameof(ScriptContentLevel)}: {ScriptContentLevel}");
 		Logger.Info(LogCategory.General, $"{nameof(StreamingAssetsMode)}: {StreamingAssetsMode}");
-		Logger.Info(LogCategory.General, $"{nameof(DefaultVersion)}: {DefaultVersion}");
-		Logger.Info(LogCategory.General, $"{nameof(TargetVersion)}: {TargetVersion}");
-	}
+                Logger.Info(LogCategory.General, $"{nameof(DefaultVersion)}: {DefaultVersion}");
+                Logger.Info(LogCategory.General, $"{nameof(TargetVersion)}: {TargetVersion}");
+                Logger.Info(LogCategory.General, $"OpenAI Key Provided: {!string.IsNullOrEmpty(OpenAIApiKey)}");
+                Logger.Info(LogCategory.General, $"Anthropic Key Provided: {!string.IsNullOrEmpty(AnthropicApiKey)}");
+        }
 }

--- a/Source/AssetRipper.Import/Structure/Assembly/AIAssembler.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/AIAssembler.cs
@@ -1,5 +1,10 @@
 using AssetRipper.Import.Logging;
 using AsmResolver.DotNet;
+using AsmResolver.DotNet.Code.Cil;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
 
 namespace AssetRipper.Import.Structure.Assembly;
 
@@ -7,15 +12,95 @@ public static class AIAssembler
 {
     public static void AssembleScripts(IEnumerable<AssemblyDefinition> assemblies)
     {
-        string? key = Environment.GetEnvironmentVariable("OPENAI_API_KEY") ??
-                     Environment.GetEnvironmentVariable("CLAUDE_API_KEY");
-        if (string.IsNullOrEmpty(key))
+        string? openAiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+        string? claudeKey = Environment.GetEnvironmentVariable("CLAUDE_API_KEY");
+        if (string.IsNullOrEmpty(openAiKey) && string.IsNullOrEmpty(claudeKey))
         {
             Logger.Warning(LogCategory.Import, "No AI API key provided. Skipping level 4 assembly.");
             return;
         }
 
         Logger.Info(LogCategory.Import, "Assembling scripts using AI service...");
-        // Placeholder for API integration with OpenAI or Claude to fill in method bodies
+
+        foreach (AssemblyDefinition assembly in assemblies)
+        {
+            foreach (TypeDefinition type in assembly.GetAllTypes())
+            {
+                foreach (MethodDefinition method in type.Methods)
+                {
+                    if (method.CilMethodBody is null && !method.IsAbstract)
+                    {
+                        string prompt = CreatePrompt(type, method);
+                        string? source = openAiKey is not null
+                                ? QueryOpenAi(openAiKey, prompt)
+                                : QueryAnthropic(claudeKey!, prompt);
+
+                        if (!string.IsNullOrEmpty(source))
+                        {
+                            method.CilMethodBody = new CilMethodBody(method);
+                            method.CilMethodBody.Instructions.Add(CilOpCodes.Ldstr, source);
+                            method.CilMethodBody.Instructions.Add(CilOpCodes.Ret);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static string CreatePrompt(TypeDefinition type, MethodDefinition method)
+    {
+        return $"Decompile the following IL method into valid C# code. Return only the code.\nType: {type.FullName}\nMethod: {method.Name}";
+    }
+
+    private static string? QueryOpenAi(string apiKey, string prompt)
+    {
+        using HttpClient client = new();
+        client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", apiKey);
+
+        var request = new
+        {
+            model = "gpt-4",
+            messages = new[] { new { role = "user", content = prompt } },
+            temperature = 0
+        };
+
+        string json = System.Text.Json.JsonSerializer.Serialize(request);
+        using StringContent content = new(json, System.Text.Encoding.UTF8, "application/json");
+        HttpResponseMessage response = client.PostAsync("https://api.openai.com/v1/chat/completions", content).GetAwaiter().GetResult();
+        if (!response.IsSuccessStatusCode)
+        {
+            Logger.Warning(LogCategory.Import, $"OpenAI request failed: {response.StatusCode}");
+            return null;
+        }
+
+        using var stream = response.Content.ReadAsStream();
+        using var doc = System.Text.Json.JsonDocument.Parse(stream);
+        return doc.RootElement.GetProperty("choices")[0].GetProperty("message").GetProperty("content").GetString();
+    }
+
+    private static string? QueryAnthropic(string apiKey, string prompt)
+    {
+        using HttpClient client = new();
+        client.DefaultRequestHeaders.Add("x-api-key", apiKey);
+
+        var request = new
+        {
+            model = "claude-3-opus-20240229",
+            max_tokens = 2048,
+            messages = new[] { new { role = "user", content = prompt } }
+        };
+
+        string json = System.Text.Json.JsonSerializer.Serialize(request);
+        using StringContent content = new(json, System.Text.Encoding.UTF8, "application/json");
+        HttpResponseMessage response = client.PostAsync("https://api.anthropic.com/v1/messages", content).GetAwaiter().GetResult();
+        if (!response.IsSuccessStatusCode)
+        {
+            Logger.Warning(LogCategory.Import, $"Anthropic request failed: {response.StatusCode}");
+            return null;
+        }
+
+        using var stream = response.Content.ReadAsStream();
+        using var doc = System.Text.Json.JsonDocument.Parse(stream);
+        return doc.RootElement.GetProperty("content")[0].GetProperty("text").GetString();
     }
 }


### PR DESCRIPTION
## Summary
- allow configuring AI API keys through ImportSettings
- expose API key fields on the settings page
- forward API keys as environment variables when loading data
- implement AIAssembler with basic OpenAI and Anthropic requests

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683d88cf6324832aaa2ef535d857c789