### PR TITLE
Fix build errors in AI Assembler

### DIFF
--- a/Source/AssetRipper.Import/Structure/Assembly/AIAssembler.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/AIAssembler.cs
@@ -1,10 +1,12 @@
 using AssetRipper.Import.Logging;
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Code.Cil;
+using AsmResolver.PE.DotNet.Cil;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using System.Linq;
 
 namespace AssetRipper.Import.Structure.Assembly;
 
@@ -24,7 +26,7 @@ public static class AIAssembler
 
         foreach (AssemblyDefinition assembly in assemblies)
         {
-            foreach (TypeDefinition type in assembly.GetAllTypes())
+            foreach (TypeDefinition type in assembly.Modules.SelectMany(m => m.GetAllTypes()))
             {
                 foreach (MethodDefinition method in type.Methods)
                 {


### PR DESCRIPTION
## Summary
- fix namespace for `CilOpCodes`
- iterate assembly types by modules

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d94d090cc832ab9d0a98843bee7ff