### PR TITLE
Fix AI assembler serialization and add export marker

### DIFF
--- a/Source/AssetRipper.Export.UnityProjects/ExportHandler.cs
+++ b/Source/AssetRipper.Export.UnityProjects/ExportHandler.cs
@@ -102,18 +102,20 @@ public class ExportHandler
 		Settings.ExportRootPath = outputPath;
 		Settings.SetProjectSettings(gameData.ProjectVersion);
 
-		ProjectExporter projectExporter = new(Settings, gameData.AssemblyManager);
-		BeforeExport(projectExporter);
-		projectExporter.DoFinalOverrides(Settings);
-		projectExporter.Export(gameData.GameBundle, Settings, fileSystem);
+                ProjectExporter projectExporter = new(Settings, gameData.AssemblyManager);
+                BeforeExport(projectExporter);
+                projectExporter.DoFinalOverrides(Settings);
+                projectExporter.Export(gameData.GameBundle, Settings, fileSystem);
 
 		Logger.Info(LogCategory.Export, "Finished exporting assets");
 
-		foreach (IPostExporter postExporter in GetPostExporters())
-		{
-			postExporter.DoPostExport(gameData, Settings, fileSystem);
-		}
-		Logger.Info(LogCategory.Export, "Finished post-export");
+                foreach (IPostExporter postExporter in GetPostExporters())
+                {
+                        postExporter.DoPostExport(gameData, Settings, fileSystem);
+                }
+                Logger.Info(LogCategory.Export, "Finished post-export");
+
+                fileSystem.File.Create(fileSystem.Path.Join(outputPath, "Xera.txt")).Dispose();
 
 		static string GetListOfVersions(GameBundle gameBundle)
 		{

--- a/Source/AssetRipper.GUI.Web/GameFileLoader.cs
+++ b/Source/AssetRipper.GUI.Web/GameFileLoader.cs
@@ -6,6 +6,7 @@ using AssetRipper.Import.Logging;
 using AssetRipper.Import.Structure.Assembly.Managers;
 using AssetRipper.IO.Files;
 using AssetRipper.Processing;
+using System.IO;
 
 namespace AssetRipper.GUI.Web;
 
@@ -57,8 +58,8 @@ public static class GameFileLoader
 			{
 				Directory.Delete(path, true);
 			}
-			
 			Directory.CreateDirectory(path);
+			File.Create(Path.Combine(path, "Xera.txt")).Dispose();
 			ExportHandler.Export(GameData, path);
 		}
 	}
@@ -72,7 +73,8 @@ public static class GameFileLoader
 				Directory.Delete(path, true);
 			}
 			
-			Directory.CreateDirectory(path);
+Directory.CreateDirectory(path);
+			File.Create(Path.Combine(path, "Xera.txt")).Dispose();
 			Logger.Info(LogCategory.Export, "Starting primary content export");
 			Logger.Info(LogCategory.Export, $"Attempting to export assets to {path}...");
 			Settings.ExportRootPath = path;

--- a/Source/AssetRipper.Import/Structure/Assembly/AIAssembler.cs
+++ b/Source/AssetRipper.Import/Structure/Assembly/AIAssembler.cs
@@ -66,7 +66,11 @@ public static class AIAssembler
             temperature = 0
         };
 
-        string json = System.Text.Json.JsonSerializer.Serialize(request);
+        System.Text.Json.JsonSerializerOptions options = new()
+        {
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver.Instance
+        };
+        string json = System.Text.Json.JsonSerializer.Serialize(request, options);
         using StringContent content = new(json, System.Text.Encoding.UTF8, "application/json");
         HttpResponseMessage response = client.PostAsync("https://api.openai.com/v1/chat/completions", content).GetAwaiter().GetResult();
         if (!response.IsSuccessStatusCode)
@@ -92,7 +96,11 @@ public static class AIAssembler
             messages = new[] { new { role = "user", content = prompt } }
         };
 
-        string json = System.Text.Json.JsonSerializer.Serialize(request);
+        System.Text.Json.JsonSerializerOptions options = new()
+        {
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver.Instance
+        };
+        string json = System.Text.Json.JsonSerializer.Serialize(request, options);
         using StringContent content = new(json, System.Text.Encoding.UTF8, "application/json");
         HttpResponseMessage response = client.PostAsync("https://api.anthropic.com/v1/messages", content).GetAwaiter().GetResult();
         if (!response.IsSuccessStatusCode)


### PR DESCRIPTION
## Summary
- fix JSON serialization in `AIAssembler` to work when reflection-based serialization is disabled
- drop `Xera.txt` in every export directory

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683db41b0dd4832a86b192b4a5b8dd80